### PR TITLE
Ajout de 2 commandes (.addon-info et .notifevent)

### DIFF
--- a/config/config.dist.json
+++ b/config/config.dist.json
@@ -21,7 +21,8 @@
 		"errors": {
 			"command": "Aïe cette commande n'existe pas, essayez-en une autre :wink:",
 			"permission": "Vous n'avez pas la permission d'utiliser cette commande :confused:",
-			"color": "#fc3e25"
+			"color": "#fc3e25",
+			"nodata": "Donnée indisponible"
 		},
 
 		"success": {

--- a/config/config.dist.json
+++ b/config/config.dist.json
@@ -21,8 +21,7 @@
 		"errors": {
 			"command": "Aïe cette commande n'existe pas, essayez-en une autre :wink:",
 			"permission": "Vous n'avez pas la permission d'utiliser cette commande :confused:",
-			"color": "#fc3e25",
-			"nodata": "Donnée indisponible"
+			"color": "#fc3e25"
 		},
 
 		"success": {

--- a/src/commands/addonInfo.js
+++ b/src/commands/addonInfo.js
@@ -36,11 +36,7 @@ export default {
 
                 if (addons.includes(myAddon.toLowerCase())) {
                     let versions;
-                    for (let a of Object.keys(data.data)) {
-                        if (a.toLowerCase() === myAddon.toLowerCase()) {
-                            versions = data.data[a];
-                        }
-                    }
+                    for (let a of Object.keys(data.data)) if (a.toLowerCase() === myAddon.toLowerCase()) versions = data.data[a];
                     let latest = versions[versions.length - 1];
                     latest = latest.replace(" ", "+");
 
@@ -49,20 +45,19 @@ export default {
                         resp2.on('data', chunk => data += chunk);
                         resp2.on('end', () => {
                             data = JSON.parse(data);
-                            const nodata = Config.messages.errors.nodata;
                             const embed = new Discord.RichEmbed()
                                 .setColor(Config.bot.color)
                                 .setAuthor(`Informations sur ${data.data.plugin}`, "https://cdn.discordapp.com/avatars/434031863858724880/296e69ea2a7f0d4e7e82bc16643cdc60.png?size=128")
-                                .setDescription(data.data.description || "Aucune description disponible.")
-                                .addField(":bust_in_silhouette: Auteur(s)", data.data.author || nodata, true)
-                                .addField(":gear: Dernière version", data.data.version || nodata, true)
-                                .addField(":inbox_tray: Lien de téléchargement", `[Téléchargez ici](${data.data.download})` || nodata, true)
-                                .addField(":computer: Code source", `[Voir ici](${data.data.sourcecode})` || nodata, true)
-                                .addField(":package: Taille", `${Math.round(data.data.bytes / 1000000)} Mo` || nodata, true)
-                                .addField(":link: Dépendences obligatoires", data.data.depend.depend || "Skript", true)
+                                .setDescription(data.data.description || "Aucune description disponible.");
+                            if (data.data.author) embed.addField(":bust_in_silhouette: Auteur(s)", data.data.author, true);
+                            if (data.data.version) embed.addField(":gear: Dernière version", data.data.version, true);
+                            if (data.data.download) embed.addField(":inbox_tray: Lien de téléchargement", `[Téléchargez ici](${data.data.download})`, true);
+                            if (data.data.sourcecode) embed.addField(":computer: Code source", `[Voir ici](${data.data.sourcecode})`, true);
+                            if (data.data.bytes) embed.addField(":package: Taille", `${Math.round(data.data.bytes / 1000000)} Mo`, true);
+                            if (data.data.depend.softdepend) embed.addField(":link: Dépendences facultatives", data.data.depend.softdepend, true);
+                            if (data.data.depend.depend) embed.addField(":link: Dépendences obligatoires", data.data.depend.depend, true)
                                 .setFooter(`Executé par ${message.author.username} | Données fournies par https://skripttools.net`);
 
-                            if (data.data.depend.softdepend) embed.addField(":link: Dépendences facultatives", data.data.depend.softdepend, true)
                             message.channel.send(embed);
                         });
                     }).on("error", err => console.error(err));

--- a/src/commands/addonInfo.js
+++ b/src/commands/addonInfo.js
@@ -1,0 +1,76 @@
+/* eslint-disable multiline-comment-style */
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-return-assign */
+/* eslint-disable sort-keys */
+import Discord from 'discord.js';
+import https from 'https';
+import Config from '../../config/config.json';
+
+/*
+ * Variables :
+ * data : Objet contenant tous les addons, chaque addons contenant 1 tableau
+ * Object.keys(data.data) : Tableau contenant tous les addons (avec case)
+ * addons : Tableau contenant tous les addons (sans case)
+ * myAddon : String avec le nom de l'addon recherché (avec case)
+ * versions : Liste de toutes les versions de l'addon recherché
+ */
+
+export default {
+
+    title: "Addon",
+    description: "Avoir diverses informations sur un addon.",
+    examples: ['addon-info', 'addonsinfos'],
+    regex: /a(?:dd?ons?)?-?infos?/gmui,
+    permissions: [],
+
+    execute: async (message, command, args) => {
+        let data = '';
+        https.get('https://api.skripttools.net/v4/addons/', resp => {
+            resp.on('data', chunk => data += chunk); // Un bout de la requête a été recu. On l'ajoute a notre data.
+            resp.on('end', () => {                   // La requête est terminée.
+                data = JSON.parse(data);
+
+                const addons = [],
+                    myAddon = args[0];
+                for (let a of Object.keys(data.data)) addons.push(a.toLowerCase());
+
+                if (addons.includes(myAddon.toLowerCase())) {
+                    let versions;
+                    for (let a of Object.keys(data.data)) {
+                        if (a.toLowerCase() === myAddon.toLowerCase()) {
+                            versions = data.data[a];
+                        }
+                    }
+                    let latest = versions[versions.length - 1];
+                    latest = latest.replace(" ", "+");
+
+                    https.get(`https://api.skripttools.net/v4/addons/${latest}`, resp2 => {
+                        data = '';
+                        resp2.on('data', chunk => data += chunk);
+                        resp2.on('end', () => {
+                            data = JSON.parse(data);
+                            const nodata = Config.messages.errors.nodata;
+                            const embed = new Discord.RichEmbed()
+                                .setColor(Config.bot.color)
+                                .setAuthor(`Informations sur ${data.data.plugin}`, "https://cdn.discordapp.com/avatars/434031863858724880/296e69ea2a7f0d4e7e82bc16643cdc60.png?size=128")
+                                .setDescription(data.data.description || "Aucune description disponible.")
+                                .addField(":bust_in_silhouette: Auteur(s)", data.data.author || nodata, true)
+                                .addField(":gear: Dernière version", data.data.version || nodata, true)
+                                .addField(":inbox_tray: Lien de téléchargement", `[Téléchargez ici](${data.data.download})` || nodata, true)
+                                .addField(":computer: Code source", `[Voir ici](${data.data.sourcecode})` || nodata, true)
+                                .addField(":package: Taille", `${Math.round(data.data.bytes / 1000000)} Mo` || nodata, true)
+                                .addField(":link: Dépendences obligatoires", data.data.depend.depend || "Skript", true)
+                                .setFooter(`Executé par ${message.author.username} | Données fournies par https://skripttools.net`);
+
+                            if (data.data.depend.softdepend) embed.addField(":link: Dépendences facultatives", data.data.depend.softdepend, true)
+                            message.channel.send(embed);
+                        });
+                    }).on("error", err => console.error(err));
+
+                } else {
+                    message.reply(`désolé, mais il est impossible d'acceder à cet addon. Es-tu sur qu'il est disponible sur <https://skripttools.net/addons?q=${args[0]}> ?`);
+                }
+            });
+        }).on("error", err => console.error(err));
+    }
+};

--- a/src/commands/addonInfo.js
+++ b/src/commands/addonInfo.js
@@ -53,7 +53,7 @@ export default {
                             if (data.data.version) embed.addField(":gear: Dernière version", data.data.version, true);
                             if (data.data.download) embed.addField(":inbox_tray: Lien de téléchargement", `[Téléchargez ici](${data.data.download})`, true);
                             if (data.data.sourcecode) embed.addField(":computer: Code source", `[Voir ici](${data.data.sourcecode})`, true);
-                            if (data.data.bytes) embed.addField(":package: Taille", `${Math.round(data.data.bytes / 1000000)} Mo`, true);
+                            if (data.data.bytes) embed.addField(":package: Taille", `~${Math.round(data.data.bytes / 1000000)} Mo`, true);
                             if (data.data.depend.softdepend) embed.addField(":link: Dépendences facultatives", data.data.depend.softdepend, true);
                             if (data.data.depend.depend) embed.addField(":link: Dépendences obligatoires", data.data.depend.depend, true)
                                 .setFooter(`Executé par ${message.author.username} | Données fournies par https://skripttools.net`);

--- a/src/commands/notifRole.js
+++ b/src/commands/notifRole.js
@@ -1,7 +1,6 @@
 /* eslint-disable sort-keys */
 /* eslint-disable no-console */
 /* eslint-disable max-statements */
-
 import Config from '../../config/config.json';
 
 const roleName = Config.miscellaneous.notifRoleName,
@@ -41,7 +40,7 @@ export default {
 					role = await messageReaction.message.guild.createRole({
 						permissions: [],
 						name: roleName,
-						mentionable: true
+						mentionable: false
 					});
 				} catch (err) {
 					// eslint-disable-next-line no-console

--- a/src/commands/tagNotifEvent
+++ b/src/commands/tagNotifEvent
@@ -1,0 +1,20 @@
+/* eslint-disable sort-keys */
+import Config from '../../config/config.json';
+const roleName = Config.miscellaneous.notifRoleName;
+
+export default {
+
+    title: "Mention Notif Évenement",
+    description: "Permet de notifier les personnes ayant le rôle \"Notifications Évenement\".",
+    examples: ['notifEvent'],
+    regex: /notifEvent/gmui,
+    permissions: ['Staff', 'Organisateur'],
+
+    execute: async message => {
+        message.delete();
+        let role = message.guild.roles.find(r => r.name === roleName);
+        if (!role.mentionable) role.setMentionable(true);
+        await message.channel.send(`${role}`);
+        if (role.mentionable) role.setMentionable(false);
+    }
+};


### PR DESCRIPTION
- Ajout d'une commande pour avoir diverses informations sur un addon.
Elle utilise l'API de skripttools.net.

- Ajout d'une commande pour tagger le rôle Notification Événement. Maintenant il n'est plus taggable, sauf via cette commande (.notifEvent).

Contrairement a ce que l'historique des commits peut montrer, je n'ai *pas* modifié la config (j'ai supprimé mes modifications dans 739ce1a)

Testé et fonctionnel
Compatible avec le fichier eslint