### PR TITLE
Nouvelles commandes, améliorations, bugfixes

### DIFF
--- a/config/config.dist.json
+++ b/config/config.dist.json
@@ -6,7 +6,16 @@
         "default_channels": [
             "459996868852711434"
         ],
-        "default_permissions": ["Staff"],
+        "forbidden_channels": [
+            "358653742729396224",
+            "549333475153412106",
+            "317341684369326084",
+            "205091190108848128",
+            "566653849738149898",
+            "570720318050795532",
+            "433720839494434826"
+        ],
+        "default_permissions": [],
         "color": "#4286f4"
     },
 
@@ -51,12 +60,38 @@
         },
         "commands": {
             "addNotifRole": {
-                "description": "Permet de vous mettre ou de vous enlever le rôle Notifications Évenement."
+                "shortDesc": "Mettre ou enlever le rôle Notifications Évenement.",
+                "longDesc": "Permet de vous mettre ou de vous enlever le rôle Notifications Évenement."
+            },
+            "auto": {
+                "shortDesc": "Envoyer un message prédéfini.",
+                "longDesc": "Envoyer un message prédéfini parmis ceux-là : `asktoask`, `helptemplate`, `internalerror`, `deprecated`. Merci de ne pas abuser de cette commande, et de l'utiliser seulement si besoin.",
+                "invalidMessage": "Désolé, mais ce message la n'existe pas...",
+                "commands": {
+                    "asktoask": {
+                        "content": "Il est inutile de demander si vous pouvez poser une question, ou de demander si quelqu'un serai capable de répondre a votre question. En conséquence, ce genre de messages est prohibé : ```Bonjour, je peux poser une question ? J'ai un problème avec mon skript```ou encore :```Quelqu'un s'y connait avec Vixio ? J'arrive pas a faire ce que je veux.```Cela est de la pure perte de temps, aussi bien pour vous que pour la personne qui va vous dire \"Oui, vas-y, pose ta question\".\nPour conclure, osez poser votre question directement, sans demander si vous pouvez ou si quelqu'un pourra vous répondre."
+                    },
+                    "helptemplate": {
+                        "content": "Voici un template de demande d'aide pour pouvoir vous aidez au mieux:\n__Ma version de skript__ (`/ver skript`): <la version>\n__Ma version de serveur__ (`/ver`): <la version>\n__Mes addons__ (`/plugins`):  <les plugins>\n__Mon problème__: <decrivez votre problème clairement>\n__Mon code:__\n```<mettez la partie du code avec le problème>```\nSi votre code dépasse les 2 000 caractères, utilisez un hastebin: <https://hastebin.com/>.\nPensez à expliquez de manière précise et courte votre problème, il donnera beaucoup plus envie aux membres de venir vous aider"
+                    },
+                    "internalerror": {
+                        "content": "Une internal error veut simplement dire qu'il y a eu une erreur java. L'erreur est affichée dans la console. Il n'y a jamais de moyen prédéfini d'en régler une, car ça peut être n'importe quelle erreur Java."
+                    },
+                    "deprecated": {
+                        "content": "Les addons suivants sont vieux, et sont abandonnées par leur auteur. Cela veut dire qu'il n'y a **plus de mises à jour, qu'ils sont donc bugués et qu'ils peuvent être nuisibles** à votre serveur. Merci de ne pas les utiliser. Voici la liste des principaux; pour savoir si un certain addon est déprecié, faites `.addon-info <addon>` :\nBiosphere, ExtraSk, LargeSk, PirateSk et PirateSk2, RandomSk, SkAction, SkellettProxy, SkExtras, SkQuery, SkRambled, Umbaska et WildSkript."
+                    }
+                }
+            },
+            "eightBall": {
+                "shortDesc": "Répond par Oui ou Non à une question que vous lui posez.",
+                "longDesc": "Le bot répondra par Oui ou Non à une n'importe quelle question que vous lui posez ! Réponse sûre garantie à 7%"
             },
             "addonInfo": {
-                "description": "Avoir diverses informations sur un addon.",
+                "shortDesc": "Avoir diverses informations sur un addon.",
+                "longDesc": "Obtenir diverses informations sur un addon, telles que son auteur, sa dernière version, un lien de téléchargement, si l'addon est déprecié, les dépendances...",
                 "addonDoesntExist": "Désolé, mais il est impossible d'accéder à cet addon. Es-tu sur qu'il est disponible sur [skripttools](<https://skripttools.net/addons?q=%s>) ? Il doit être orthographié exactement pareil !",
                 "invalidCmd": "Il faut que tu ajoutes le nom d'un addon ! Vérifie qu'il soit disponible sur [skripttools](<https://skripttools.net/>) et orthographie-le de la même manière. Les majuscules n'importes pas.",
+                "list": "Liste des addons disponibles : `%s`",
                 "embed": {
                     "author": ":bust_in_silhouette: Auteur(s)",
                     "version": ":gear: Dernière version",
@@ -69,7 +104,8 @@
                 }
             },
             "syntaxInfo": {
-                "description": "Avoir diverses informations sur une syntaxe.",
+                "shortDesc": "Avoir diverses informations sur une syntaxe.",
+                "longDesc": "Avoir diverses informations sur une syntaxe, telle que l'addon nécessaire, le pattern, un exemple... Vous devez chercher une syntaxe avec des mots clés qui seront cherchés dans le nom ou la description. Vous pouvez ensuite affiner vos recherche un spécifiant un addon, un type ou une ID skripthub.",
                 "syntaxDoesntExist": "Aucune syntaxe ne correspond a votre recherche... Nous avons pourtant essayer de rechercher dans le titre et dans la description... Désolé.",
                 "invalidCmd": "Il faut que tu ajoutes le nom d'une syntaxe ! Vérifie qu'il soit disponible sur [la documentation skripthub](<https://skripthub.net/docs>).",
                 "requestError": "Désolé, une erreur est survenue... Réessayez plus tard. Si cela ne fonctionne toujours pas, veuillez contacter un administrateur.",
@@ -86,7 +122,8 @@
                 }
             },
             "skriptInfo": {
-                "description": "Avoir diverses informations sur skript.",
+                "shortDesc": "Avoir diverses informations sur Skript.",
+                "longDesc": "Avoir diverses informations sur Skript, telles que sa version actuelle, un lien de téléchargement, les versions de Skript à utiliser selon la version minecraft...",
                 "embed": {
                     "author": ":bust_in_silhouette: Auteur(s)",
                     "version": ":gear: Dernière version",
@@ -96,14 +133,15 @@
                     "sourcecode": ":computer: Code source"
                 }
             },
-            "event": {
-                "description": "Lancer un événement Skript-MC."
-            },
             "help": {
-                "description": "Afficher la page d'aide des commandes de Swan."
+                "shortDesc": "Afficher la page d'aide.",
+                "longDesc": "Afficher la page d'aide de toutes les commandes de Swan, ou donne des informations sur une commande spécifique.",
+                "header": "Les tirets (-) dans les commandes sont facultatifs. Les arguments entre chevrons <> sont obligatoires. Ceux entre crochets [] sont facultatifs. Faites `.help <nom de la commande>` pour avoir plus d'informations sur une commande.",
+                "cmdDoesntExist": "Aucune commande ne correspond a votre recherche...  Désolé."
             },
             "links": {
-                "description": "Avoir plusieurs liens importants relatifs à Skript.",
+                "shortDesc": "Avoir plusieurs liens importants relatifs à Skript.",
+                "longDesc": "Avoir plusieurs liens importants relatifs à Skript, tels que des documentations, des forums, des liens de téléchargement, des discords...",
                 "embed": {
                     "summary": "Voici la liste des liens importants relatifs à Skript. Sommaire :\n:zero: Sommaire\n:one: Liens sur les documentations de Skript\n:two: Liens sur les documentations des addons de Skript\n:three: Liens de téléchargement de Skript et de ses addons\n:four: Liens vers des discord importants\n:five: Divers liens importants",
                     "docSkSkMc_title": ":books: Doc Skript de SkriptMC : https://bit.ly/2KSZ6pN",
@@ -129,19 +167,29 @@
                 }
             },
             "poll": {
-                "description": "Lancer un sondage par lequel on peut répondre Oui ou Non.",
+                "shortDesc": "Lancer un sondage.",
+                "longDesc": "Lancer un sondage temporaire par lequel on peut répondre Oui ou Non.",
                 "invalidCmd": "Il doit y avoir un problème dans ta commande... Vérifie qu'elle soit construite de cette façon :\n```.sond DURÉE TITRE DESCRIPTION```\n**DURÉE** est composée d'un nombre suivis sans espaces de `s` pour `seconde` ou de `min` pour `minute` ou de `h` pour `heure` ou de `j` pour `jour`.\n**TITRE** est un texte, sans espace. Les \"_\" du titre seront convertis en espaces.\n**DESCRIPTION** est un texte, avec espace. Ce champs est facultatif.\nExemple de commande : ```.sond 10min Mon_titre Mon sondage !```",
                 "pollInfos": "**Informations sur les sondages :**\nRéagissez par :white_check_mark: pour voter Oui à la question posée, ou réagissez par :x: pour voter Non. Au bout du temps définit, le décompte des votes est fait. Si vous enlevez votre réaction, elle sera tout de même comptée. Si vous mettez plusieurs réaction, c'est la 1ère mise qui sera comptée. Le vote commence lorsque l'embed devient bleu. Pour arrêter un vote, cliquez sur :octagonal_sign:.",
                 "tooLong": "Désolé, mais la durée indiquée pour ce sondage est trop longue. Le maximum autorisé est de 7 jours (%sms)."
             },
-            "tagNotifEvent": {
-                "description": "Permet de notifier les personnes ayant le rôle \"Notifications Évenement\"."
+            "tagRole": {
+                "shortDesc": "Permet de notifier un rôle qui n'est pas mentionnable.",
+                "longDesc": "Permet de notifier un rôle qui n'est pas mentionnable.",
+                "invalidCmd": "Il faut ajouter un rôle a mentionner !",
+                "invalidRole": "Désolé, mais le rôle '%s' est introuvable... Êtes-vous sûr de l'avoir orthographié de la même façon ?"
             },
             "ping": {
-                "description": "Permet de savoir le ping du bot."
+                "shortDesc": "Permet de savoir le ping du bot.",
+                "longDesc": "Permet de savoir la latence entre vous et le bot."
+            },
+            "math": {
+                "shortDesc": "Permet de savoir le ping du bot.",
+                "longDesc": "Permet de savoir la latence entre vous et le bot."
             },
             "ban": {
-                "description": "Appliquer une restriction du discord à un joueur",
+                "shortDesc": "Appliquer une restriction du discord à un joueur.",
+                "longDesc": "Appliquer une restriction du discord à un joueur.",
                 "missingUserArgument": "Vous n'avez pas spécifié d'utilisateur *(mention ou ID)* !",
                 "missingTimeArgument": "Vous n'avez pas spécifié de durée !",
                 "unableToSelfBan": "Vous ne pouvez pas vous bannir vous même !",
@@ -152,7 +200,8 @@
                 "whyHere": "Bonjour %u ! Si tu te retrouves ici, c'est surement car tu as du enfreindre le réglement.... En tout cas un modérateur a décidé de te punir... de te bannir pour ainsi dire. Essaye de te justifier une dernière fois avant la sanction finale :wink: GLHF\n*(PS: désolé je n'y suis pour rien, je ne fais qu'executer les ordres, je suis un robot après tout.... bip boup bip bip)*"
             },
             "mute": {
-                "description": "Rendre muet un joueur !",
+                "shortDesc": "Rendre muet un joueur.",
+                "longDesc": "Rendre muet un joueur.",
                 "missingUserArgument": "Vous n'avez pas spécifié d'utilisateur *(mention ou ID)* !",
                 "missingTimeArgument": "Vous n'avez pas spécifié de durée !",
                 "unableToSelfMute": "Vous ne pouvez pas vous rendre muet vous même !",
@@ -162,7 +211,8 @@
                 "alreadyMuted": "%u est déjà muet."
             },
             "purge": {
-                "description": "Supprimer des messages dans un channel",
+                "shortDesc": "Supprimer des messages dans un channel.",
+                "longDesc": "Supprimer X messages dans un channel, selon un certain utilisateur ou non. La limite est fixée à 100.",
                 "missingNumberArgument": "Vous devez spécifier un nombre de messages a supprimer !",
                 "wrongUsage": "Tu dois spécifier soit un utilisateur et un nombre de message, soit seulement un nombre de message a supprimer !"
             }
@@ -175,6 +225,8 @@
         "api_addons": "https://api.skripttools.net/v4/addons/",
         "api_skript": "https://api.skripttools.net/v4/skript/",
         "api_syntax": "https://skripthub.net/api/v1",
-        "tokenApiSyntax": ""
+        "tokenApiSyntax": "",
+        "cmdPerPagesInHelp": 10,
+        "purgeLimit": 100
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -445,6 +445,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "complex.js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
+      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -516,6 +521,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decimal.js": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.1.1.tgz",
+      "integrity": "sha512-vEEgyk1fWVEnv7lPjkNedAIjzxQDue5Iw4FeX4UkNUDSVyD/jZTD0Bw2kAO7k6iyyJRAhM9oxxI0D1ET6k0Mmg=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -630,6 +640,11 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -824,6 +839,11 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
+    },
+    "fraction.js": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.12.tgz",
+      "integrity": "sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -1725,6 +1745,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -1798,6 +1823,21 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "mathjs": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.9.0.tgz",
+      "integrity": "sha512-f1xmJklkTCr48y023cFy/ZSoVzOfgHp1gutvebi/Vv5RLly6j8G9T2/XHkfXewZKcwPDbhBkFEYljaCjudxulQ==",
+      "requires": {
+        "complex.js": "2.0.11",
+        "decimal.js": "10.1.1",
+        "escape-latex": "1.2.0",
+        "fraction.js": "4.0.12",
+        "javascript-natural-sort": "0.7.1",
+        "seed-random": "2.2.0",
+        "tiny-emitter": "2.1.0",
+        "typed-function": "1.1.0"
       }
     },
     "micromatch": {
@@ -2508,6 +2548,11 @@
         "ret": "~0.1.10"
       }
     },
+    "seed-random": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -2807,6 +2852,11 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -2886,6 +2936,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
       "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+    },
+    "typed-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-1.1.0.tgz",
+      "integrity": "sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA=="
     },
     "typescript": {
       "version": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "authors": [
     "AlexLew",
-    "Uiytt",
-    "Noftaly",
+    "uiytt",
+    "noftaly",
     "Uneo7"
   ],
   "license": "ISC",
@@ -17,6 +17,7 @@
     "@types/node": "^11.13.7",
     "axios": "^0.18.0",
     "discord.js": "^11.4.2",
+    "mathjs": "^5.9.0",
     "node-fetch": "^2.5.0",
     "opusscript": "0.0.6",
     "typescript": "^3.4.4"

--- a/src/commands/8ball.ts
+++ b/src/commands/8ball.ts
@@ -1,0 +1,27 @@
+import { Message } from "discord.js";
+import Command from '../components/Command';
+import config from "../../config/config.json";
+
+const affirmative = ['Oui.', 'Oui !', 'D\'après moi, oui !', 'Je le pense', 'C\'est une chose sûre !', 'C\'est certain.', 'Sans aucun doutes', 'Il me semble...', 'Pourquoi demander ? La réponse parait évidente ! Oui !', 'ET C\'EST UN OUI !', 'Oui ! NAN J\'AI PERDU :sob: Je suis vraiment nul au ni-oui ni-non :weary: ', 'Affirmatif, chef.', 'Positif.'];
+const negative = ['Non.', 'MDR NON', 'C\'est un non.', 'Mes sources me confirment que non.', 'C\'est mieux que tu ne sois pas au courant...', 'Bien sur que non !', 'Je ne suis pas sur de comprendre... Dans le doute je vais dire non.', 'Question très compliquée... Mais je dirai non.', 'Ou... Non ! C\'est Non !', 'Bien sur que non...', 'Négatif', 'Je répondrai par la négation. Rah chui trop fort à ni-oui ni-non ! Tu me battras jamais :wink:', 'Sûrement pas.'];
+
+class EightBall extends Command {
+
+	name: string = '8Ball';
+	shortDescription: string = config.messages.commands.eightBall.shortDesc;
+	longDescription: string = config.messages.commands.eightBall.longDesc;
+	usage: string = `${config.bot.prefix}8ball <question>`;
+	examples: string[] = ['8ball suis-je le plus beau ?'];
+	regex: RegExp = /(?:8|eight)-?ball/gmui;
+
+	execute = async (message: Message, args: string[]): Promise<void> => {
+		let answer: string;
+		if (Math.random() < 0.5)
+			answer = affirmative[Math.floor(Math.random() * affirmative.length)];
+		else
+			answer = negative[Math.floor(Math.random() * negative.length)];
+        message.channel.send(answer);
+	}
+};
+
+export default EightBall;

--- a/src/commands/addNotifRole.ts
+++ b/src/commands/addNotifRole.ts
@@ -1,14 +1,16 @@
-import Discord, { Message, Role, GuildMember } from "discord.js";
+import { Message, Role, GuildMember } from "discord.js";
 import Command from '../components/Command';
 import config from "../../config/config.json";
 
 const roleName = config.miscellaneous.notifRoleName;
 
-class AddNotifRole extends Command {
+class ToggleNotifRole extends Command {
 
-	name: string = 'Ajout role notification';
-	description: string = config.messages.commands.addNotifRole.description;
-	examples: string[] = ['add-notif-role', 'toggle-notif-role'];
+	name: string = 'Toggle role notification';
+	shortDescription: string = config.messages.commands.addNotifRole.shortDesc;
+	longDescription: string = config.messages.commands.addNotifRole.longDesc;
+	usage: string = `${config.bot.prefix}toggle-notif-role`;
+	examples: string[] = ['toggle-notif-role'];
 	regex: RegExp = /(?:add|give|ask|toggle)-?notif(?:ication)?-?role/gmui;
 
 	execute = async (message: Message, args: string[]): Promise<void> => {
@@ -38,4 +40,4 @@ class AddNotifRole extends Command {
 	}
 };
 
-export default AddNotifRole;
+export default ToggleNotifRole;

--- a/src/commands/addonInfo.ts
+++ b/src/commands/addonInfo.ts
@@ -51,8 +51,11 @@ async function sendEmbed(message: Message, data: any) {
 class AddonInfo extends Command {
 
 	name: string = "Addon";
-	description: string = conf.description;
-	examples: string[] = ["addon-info", "addonsinfos"];
+	shortDescription: string = conf.shortDesc;
+	longDescription: string = conf.longDesc;
+	usage: string = `${config.bot.prefix}addon-info <addon>`;
+	examples: string[] = ["addon-info skquery-lime", "addonsinfos -list"];
+	channels: string[] = ['*'];
 	regex: RegExp = /a(?:dd?ons?)?-?infos?/gimu;
 
 	execute = async (message: Message, args: string[]): Promise<void> => {
@@ -73,6 +76,9 @@ class AddonInfo extends Command {
 					for (let addon of Object.keys(data.data)) {
 						addons.push(addon.toLowerCase());
 					}
+
+					if (args[0] === "-list")
+						return message.channel.send(conf.list.replace('%s', addons.join(', ')));
 
 					if (addons.includes(myAddon.toLowerCase())) {
 						for (let addon of Object.keys(data.data)) {

--- a/src/commands/automaticMessages.ts
+++ b/src/commands/automaticMessages.ts
@@ -1,0 +1,33 @@
+import { Message } from "discord.js";
+import Command from '../components/Command';
+import config from "../../config/config.json";
+
+const conf: any = config.messages.commands.auto.commands;
+
+class AutomaticMessages extends Command {
+
+	name: string = 'Messages automatiques';
+	shortDescription: string = config.messages.commands.auto.shortDesc;
+	longDescription: string = config.messages.commands.auto.longDesc;
+	usage: string = `${config.bot.prefix}auto <message>`;
+	examples: string[] = ['auto asktoask'];
+	channels: string[] = ['*'];
+	regex: RegExp = /auto(?:mati(?:que|c))?-?(?:messages?)?/gmui;
+
+	execute = async (message: Message, args: string[]): Promise<void> => {
+		if (args[0] === 'asktoask')
+			message.channel.send(conf.asktoask.content);
+		else if (args[0] === 'helptemplate')
+			message.channel.send(conf.helptemplate.content);
+		else if (args[0] === 'internal' || args[0] === 'internalerror')
+			message.channel.send(conf.internalerror.content);
+		else if (args[0] === 'deprecated' || args[0] === 'oldaddon')
+			message.channel.send(conf.deprecated.content);
+		else if (args[0] === 'opinion')
+			message.channel.send({ files: [{ attachment: 'https://cdn.discordapp.com/attachments/460036535845388301/573493651112591360/img-22223753dff.jpg', name: 'opinion.jpg' }] });
+		else
+			message.channel.send(conf.invalidMessage)
+	}
+};
+
+export default AutomaticMessages;

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -62,9 +62,13 @@ async function createChan(message: Message, victim: GuildMember): Promise<any> {
 class Ban extends Command {
 
 	name: string = 'Ban';
-	description: string = conf.description;
+	shortDescription: string = conf.shortDesc;
+	longDescription: string = conf.longDesc;
+	usage: string = `${config.bot.prefix}ban <@mention | ID> <durée> [raison]`;
 	examples: string[] = ['ban'];
+	channels: string[] = ['*'];
 	regex: RegExp = /ban/gmui;
+	permissions: string[] = ['Staff'];
 
 	execute = async (message: Message, args: string[]): Promise<any> => {
 		const victim: GuildMember = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,68 +1,134 @@
-import Discord, { Message } from "discord.js";
+import { Message, RichEmbed, ReactionCollector } from "discord.js";
 import config from "../../config/config.json";
 import Command from "../components/Command";
 import { commands } from "../main";
+import { discordError } from "../components/Messages";
+
+const conf = config.messages.commands.help;
+const reactions: string[] = ["⏮", "◀", "🇽", "▶", "⏭"];
+const cmdPerPage: number = config.miscellaneous.cmdPerPagesInHelp;
+const reactionsNumbers: Array<string> = ['1⃣', '2⃣', '3⃣', '4⃣', '5⃣', '6⃣', '7⃣', '8⃣', '9⃣', '🔟'];
+
+async function sendEmbed(message: Message, command: any) {
+	const embed: RichEmbed = new RichEmbed()
+		.setColor(config.bot.color)
+		.setAuthor(`Informations sur "${command.name}"`, "https://cdn.discordapp.com/avatars/434031863858724880/296e69ea2a7f0d4e7e82bc16643cdc60.png?size=128")
+		.setFooter(`Executé par ${message.author.username} | Données fournies par https://skripthub.net`)
+
+	let perms: string = "";
+	for (let perm of command.permissions)
+		perms = `${perms}, ${perm}`;
+	perms = perms.slice(2); // Enlève la virgule et l'espace au début
+	perms = perms === "" ? "Tout le monde." : `${perms}.`;
+	
+	let ex: string = "";
+	for (let e of command.examples)
+		ex = `${ex} | \`${config.bot.prefix}${e}\``;
+	ex = ex.slice(3, ex.length - 1); // Enlève les espaces et la barre au début, et l'espace et le ` à la fin.
+	ex = ex === "" ? "Aucun exemple disponible." : `${ex}`;
+	embed.addField(`:star: **${command.name}**`, `**Description :** ${command.longDescription}\n**Utilisation :** ${command.usage}\n**Exemple d'utilisation :** ${ex}\`\n**Utilisable par :** ${perms}\n‌‌ `, true);
+
+	message.channel.send(embed);
+}
 
 class Help extends Command {
 	
 	name: string = "Aide";
-	description: string = config.messages.commands.help.description;
-	examples: string[] = ["help"];
+	shortDescription: string = config.messages.commands.help.shortDesc;
+	longDescription: string = config.messages.commands.help.longDesc;
+	usage: string = `${config.bot.prefix}help [commande]`;
+	examples: string[] = ['help'];
 	regex: RegExp = /(?:aide|help)/gimu;
 
 	execute = async (message: Message, args: string[], page?: number): Promise<void> => {
-	   
 		page = Number.isInteger(page) ? page : 0;
-	   
+
 		const allCmds: Command[] = await commands;
-		const total: number = allCmds.length;
-		const reactions: string[] = ["⏮", "◀", "🇽", "▶", "⏭"];
-		const embed: Discord.RichEmbed = new Discord.RichEmbed()
-			.setColor(config.bot.color)
-			.setAuthor(`Commandes disponibles (${page + 1}/${total})`, "https://cdn.discordapp.com/avatars/434031863858724880/296e69ea2a7f0d4e7e82bc16643cdc60.png?size=128" + "")
-			.setDescription("‌‌ ") // Caractère invisible (‌‌ )
-			.setFooter("Executé par " + message.author.username);
+		const totalPages: number = Math.ceil(allCmds.length / cmdPerPage);
 
-		const cmd: any = allCmds[page];
+		// S'il n'y a pas d'arguments, on montre la liste de toutes les commandes
+		if (args.length === 0) {
+			const embed: RichEmbed = new RichEmbed()
+				.setColor(config.bot.color)
+				.setAuthor(`${allCmds.length} commandes disponibles (page ${page + 1}/${totalPages})`, "https://cdn.discordapp.com/avatars/434031863858724880/296e69ea2a7f0d4e7e82bc16643cdc60.png?size=128" + "")
+				.setDescription(config.messages.commands.help.header)
+				.setFooter("Executé par " + message.author.username);
+			//⁕※⌶⎪►▷◉◈
+			for (let i = 0; i < cmdPerPage && i < page * cmdPerPage + cmdPerPage && page * cmdPerPage + i <= allCmds.length - 1; i++) {
+				const cmd: any = allCmds[page * cmdPerPage + i];
+				embed.addField(`${cmd.name} ⁕ ${cmd.usage}`, `${cmd.shortDescription}`, false);
+			}
+			const msgHelp: Message = <Message> await message.channel.send(embed);
+			for (let r of reactions) await msgHelp.react(r);
 
-		let perms: string = "";
-		for (let perm of cmd.permissions) perms = `${perms}, ${perm}`;
-		perms = perms.slice(2); // Enlève la virgule et l'espace au début
-		perms = perms === "" ? "Tout le monde." : `${perms}.`;
+			const collector: ReactionCollector = msgHelp
+				.createReactionCollector(
+					(reaction, user) =>
+						user.id === message.author.id &&
+						reactions.includes(reaction.emoji.name)
+				)
+				.once("collect", reaction => {
+					msgHelp.delete();
+					if (reaction.emoji.name === "⏮") {
+						this.execute(message, args, 0);
+					} else if (reaction.emoji.name === "◀") {
+						const prevPage: number = page <= 0 ? totalPages - 1 : page - 1;
+						this.execute(message, args, prevPage);
+					} else if (reaction.emoji.name === "🇽") {
+						message.delete();
+					} else if (reaction.emoji.name === "▶") {
+						const nextPage: number = page + 1 >= totalPages ? 0 : page + 1;
+						this.execute(message, args, nextPage);
+					} else if (reaction.emoji.name === "⏭") {
+						this.execute(message, args, totalPages - 1);
+					}
+					collector.stop();
+				});
+		// S'il y a un argument, on recherche la commande demandée
+		} else {
+			let cmds: any[] = allCmds.filter(elt => elt.name.toUpperCase().includes(args.join(' ').toUpperCase()));
+			
+			const results: number = cmds.length;
 
-		let ex: string = "";
-		for (let e of cmd.examples) ex = `${ex} | \`${config.bot.prefix}${e}\``;
-		ex = ex.slice(3, ex.length - 1); // Enlève les espaces et la barre au début, et l'espace et le ` à la fin.
-		ex = ex === "" ? "Aucun exemple disponible." : `${ex}`;
-
-		embed.addField(`:star: **${cmd.name}**`, `**Description :** ${cmd.description}\n**Exemple d'utilisation :** ${ex}\`\n**Utilisable par :** ${perms}\n‌‌ `,true);
-
-		const msgHelp: Message = <Message> await message.channel.send(embed);
-		for (let r of reactions) await msgHelp.react(r);
-
-		const collector: Discord.ReactionCollector = msgHelp
-			.createReactionCollector(
-				(reaction, user) =>
-					user.id === message.author.id &&
-					reactions.includes(reaction.emoji.name)
-			)
-			.once("collect", reaction => {
-				msgHelp.delete();
-				if (reaction.emoji.name === "⏮") {
-					this.execute(message, args, 0);
-				} else if (reaction.emoji.name === "◀") {
-					const prevPage: number = page <= 0 ? allCmds.length - 1 : page - 1;
-					this.execute(message, args, prevPage);
-				} else if (reaction.emoji.name === "🇽") {
-					message.delete();
-				} else if (reaction.emoji.name === "▶") {
-					const nextPage: number = page + 1 >= allCmds.length ? 0 : page + 1;
-					this.execute(message, args, nextPage);
-				} else if (reaction.emoji.name === "⏭") {
-					this.execute(message, args, allCmds.length - 1);
+			// On limite a 10 élements. Plus simple a gérer pour le moment, on pourra voir + tard si on peut faire sans. (donc multipages et tout)
+			cmds = cmds.slice(0, 10);
+			
+			if (cmds.length === 0) {
+				return discordError(conf.cmdDoesntExist, message);
+			} else if (cmds.length === 1) {
+				return sendEmbed(message, cmds[0]);
+			} else {
+				let msgHub: Message = <Message> await message.channel.send(`${results} élements trouvés pour la recherche \`${args.join(' ')}\`. Quelle commande vous intéresse ?\n:warning: **Attendez que la réaction :x: soit posée avant de commencer.**`);
+				for (let i: number = 0; i < cmds.length; i++) {
+					msgHub = <Message> await msgHub.edit(`${msgHub.content}\n${reactionsNumbers[i]} \"${cmds[i].name}\" (\`${cmds[i].usage}\`)`);
+					await msgHub.react(reactionsNumbers[i]);
 				}
-				collector.stop();
-			});
+				await msgHub.react('❌');
+
+				const collectorNumbers: ReactionCollector = msgHub
+					.createReactionCollector((reaction, user) =>
+						!user.bot &&
+						user.id === message.author.id &&
+						reactionsNumbers.includes(reaction.emoji.name)
+					).once("collect", reaction => {
+						msgHub.delete();
+						sendEmbed(message, cmds[reactionsNumbers.indexOf(reaction.emoji.name)]);
+						collectorNumbers.stop();
+					});
+
+				const collectorStop: ReactionCollector = msgHub
+					.createReactionCollector((reaction, user) =>
+						!user.bot &&
+						user.id === message.author.id &&
+						reaction.emoji.name === '❌'
+					).once("collect", () => {
+						message.delete();
+						msgHub.delete();
+						collectorNumbers.stop();
+						collectorStop.stop();
+					});
+			}
+		}
 	};
 }
 

--- a/src/commands/links.ts
+++ b/src/commands/links.ts
@@ -11,8 +11,11 @@ const conf = config.messages.commands.links;
 class Links extends Command {
 
 	name: string = "Liens importants";
-	description: string = conf.description;
+	shortDescription: string = conf.shortDesc;
+	longDescription: string = conf.longDesc;
+	usage: string = `${config.bot.prefix}liens`;
 	examples: string[] = ['lien', 'liens', 'links'];
+	channels: string[] = ['*'];
 	regex: RegExp = /(?:link|lien)s?/gmui;
 
 	execute = async (message: Message, args: string[], page?: number): Promise<void> => {

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -1,0 +1,46 @@
+import { Message } from "discord.js";
+import Command from '../components/Command';
+import config from "../../config/config.json";
+import math from 'mathjs';
+import { discordError } from "../components/Messages";
+const parser = math.parser()
+
+class Math extends Command {
+
+	name: string = 'Mathématiques';
+	shortDescription: string = config.messages.commands.math.shortDesc;
+	longDescription: string = config.messages.commands.math.longDesc;
+	usage: string = `${config.bot.prefix}math <expression mathématique de skript>`;
+	examples: string[] = ['math `sqrt(12) + 18 - abs(-13)`'];
+	regex: RegExp = /(?:maths?|eval)/gmui;
+
+	execute = async (message: Message, args: string[]): Promise<void> => {
+		let expr: string = args.join(' ');
+		expr
+			.replace(/abs/gimu, 'Math.abs')
+			.replace(/acos/gimu, 'Math.acos')
+			.replace(/asin/gimu, 'Math.asin')
+			.replace(/atan\(/gimu, 'Math.atan(')
+			.replace(/atan2\(/gimu, 'Math.atan2(')
+			.replace(/ceil/gimu, 'Math.ceil')
+			.replace(/cos/gimu, 'Math.cos')
+			.replace(/exp\(/gimu, 'Math.ceil(')
+			.replace(/floor/gimu, 'Math.floor')
+			.replace(/ln/gimu, 'Math.log')
+			.replace(/log/gimu, 'Math.log10')
+			.replace(/round/gimu, 'Math.round')
+			.replace(/sin/gimu, 'Math.sin')
+			.replace(/sqrt/gimu, 'Math.sqrt')
+			.replace(/tan/gimu, 'Math.tan');
+		expr.replace(/mod\((\d+),\s*(\d+)\)/, '$1 % $2');
+
+		try {
+			expr = parser.eval(expr)
+		} catch(err) {
+			return discordError("Il semblerai qu'il y ai un problème dans ton expression...", message);
+		}
+		message.reply(`\`${expr}\` = \`${expr}\``);
+	}
+};
+
+export default Math;

--- a/src/commands/mute.ts
+++ b/src/commands/mute.ts
@@ -43,9 +43,13 @@ async function createRole(message: Message): Promise<Role> {
 class Mute extends Command {
 
 	name: string = 'Mute';
-	description: string = conf.description;
+	shortDescription: string = conf.shortDesc;
+	longDescription: string = conf.longDesc;
+	usage: string = `${config.bot.prefix}mute <@mention | ID> <durée> [raison]`;
 	examples: string[] = ['mute'];
+	channels: string[] = ['*'];
 	regex: RegExp = /mute/gmui;
+	permissions: string[] = ['Staff'];
 
 	execute = async (message: Message, args: string[]): Promise<any> => {
 		const victim: GuildMember = message.guild.member(message.mentions.users.first()) || message.guild.members.get(args[0]);

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -5,7 +5,9 @@ import config from "../../config/config.json";
 class Ping extends Command {
 
 	name: string = 'Ping';
-	description: string = config.messages.commands.tagNotifEvent.description;
+	shortDescription: string = config.messages.commands.ping.shortDesc;
+	longDescription: string = config.messages.commands.ping.longDesc;
+	usage: string = `${config.bot.prefix}ping`;
 	examples: string[] = ['ping'];
 	regex: RegExp = /(?:ping|ms)/gmui;
 

--- a/src/commands/poll.ts
+++ b/src/commands/poll.ts
@@ -26,8 +26,11 @@ function endPoll(msg: Message, embed: RichEmbed, collectors: any, results: any) 
 class Poll extends Command {
 
 	name: string = 'Sondage';
-	description: string = config.messages.commands.poll.description;
+	shortDescription: string = config.messages.commands.poll.shortDesc;
+	longDescription: string = config.messages.commands.poll.longDesc;
+	usage: string = `${config.bot.prefix}poll <durée> <titre_sans_espaces> [description avec espaces]`;
 	examples: string[] = ['poll 10min Mon_titre Ma description'];
+	channels: string[] = ['*']; // Juste accueil, salon pleureuse, bot, salon boss. A modifier avec les bons ID.
 	regex: RegExp = /poll|vote|sond(?:age)?/gmui;
 	permissions: string[] = this.permissions.concat(['Staff', 'Membre Actif']);
 

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -7,17 +7,21 @@ import { client } from "../main";
 class Purge extends Command {
 
 	name: string = 'Purge';
-	description: string = config.messages.commands.purge.description;
+    shortDescription: string = config.messages.commands.purge.shortDesc;
+	longDescription: string = config.messages.commands.purge.longDesc;
+	usage: string = `${config.bot.prefix}purge [@mention] <nombre>`;
 	examples: string[] = ['purge @utilisateur 20', 'purge 50'];
 	regex: RegExp = /purge/gmui;
 	channels: string[] = ['*'];
+	permissions: string[] = ['Staff'];
 
 	execute = async (message: Message, args: string[]): Promise<void> => {
         const user = message.mentions.users.first();
-        const amount: number = !!parseInt(args[0]) ? parseInt(args[0]) + 1 : parseInt(args[1]) + 1
+        let amount: number = !!parseInt(args[0]) ? parseInt(args[0]) + 1 : parseInt(args[1]) + 1
 
         if (!amount) return discordError(config.messages.commands.purge.missingNumberArgument, message);
         if (!amount && !user) return discordError(config.messages.commands.purge.wrongUsage, message);
+        if (amount > config.miscellaneous.purgeLimit) amount = config.miscellaneous.purgeLimit;
 
         message.channel.fetchMessages({
             limit: amount,
@@ -27,7 +31,7 @@ class Purge extends Command {
                 const filterBy = user ? user.id : cli.user.id;
                 messages = messages.filter((m: any) => m.author.id === filterBy).array().slice(0, amount);
          }
-         message.channel.bulkDelete(messages).catch(err => console.error(err));
+        message.channel.bulkDelete(messages).catch(err => console.error(err));
         });
         
 	}

--- a/src/commands/skriptInfo.ts
+++ b/src/commands/skriptInfo.ts
@@ -34,7 +34,9 @@ async function sendEmbed(message: Message, data: any) {
 class SkriptInfo extends Command {
 
 	name: string = 'Skript';
-	description: string = config.messages.commands.addonInfo.description;
+	shortDescription: string = config.messages.commands.addonInfo.shortDesc;
+	longDescription: string = config.messages.commands.addonInfo.longDesc;
+	usage: string = `${config.bot.prefix}skript-info`;
 	examples: string[] = ['skriptInfo'];
 	regex: RegExp = /s(?:k|c)(?:ript?)?-?infos?/gimu;
 

--- a/src/commands/syntaxInfo.ts
+++ b/src/commands/syntaxInfo.ts
@@ -11,8 +11,6 @@ const regexType: RegExp = new RegExp(/-t(?:ype)?:/, 'gimu');
 const regexID: RegExp = new RegExp(/-i(?:d)?:/, 'gimu');
 
 function computeScore(score: number): string {
-	console.log(score);
-	console.log(score + 1);
 	if (score < -5) return "Très mauvais";
 	else if (score < 0) return "Mauvais";
 	else if (score === 0) return "Neutre";
@@ -58,8 +56,9 @@ async function sendEmbed(message: Message, data: any) {
 		.setColor(config.bot.color)
 		.setAuthor(`Informations sur "${data.title}"`, "https://cdn.discordapp.com/avatars/434031863858724880/296e69ea2a7f0d4e7e82bc16643cdc60.png?size=128")
 		.setFooter(`Executé par ${message.author.username} | Données fournies par https://skripthub.net`)
-		.addField(conf.embed.patternTitle, conf.embed.patternDesc.replace('%s', `${data.syntax_pattern}`) || conf.embed.noPattern, false)
-		.addField(conf.embed.descriptionTitle, data.description || conf.embed.noDescription, false)
+		.setDescription("	‌")
+		.addField(conf.embed.patternTitle, `${conf.embed.patternDesc.replace('%s', `${data.syntax_pattern}`) || conf.embed.noPattern}\n	‌`, false)
+		.addField(conf.embed.descriptionTitle, `${data.description || conf.embed.noDescription}\n	‌`, false)
 	if (data.example) {
 		let ex: string = `${conf.embed.exampleDesc.replace('%s', data.example.example_code)}\n`;
 		if (data.example.example_author) ex += `Auteur : ${data.example.example_author}\n`;
@@ -77,7 +76,9 @@ async function sendEmbed(message: Message, data: any) {
 class SyntaxInfo extends Command {
 
 	name: string = 'Syntaxe';
-	description: string = conf.description;
+	shortDescription: string = conf.shortDesc;
+	longDescription: string = conf.longDesc;
+	usage: string = `${config.bot.prefix}syntax-info <syntaxe> [-a:<addon>] [-t:<type>] [-id:<ID skripthub>]`;
 	examples: string[] = ['syntax-info join', 's-info tablist', 'sinfo tablist -addon:skrayfall', 'sinfo -id:2000', 'sinfo join -type:event'];
 	regex: RegExp = /s(?:yntaxe?)?-?infos?/gimu;
 
@@ -116,6 +117,8 @@ class SyntaxInfo extends Command {
 			if (id)
 				matchingSyntaxes = matchingSyntaxes.filter(elt => elt.id === id);
 
+			const results: number = matchingSyntaxes.length;
+			
 			// On limite a 10 élements. Plus simple a gérer pour le moment, on pourra voir + tard si on peut faire sans. (donc multipages et tout)
 			matchingSyntaxes = matchingSyntaxes.slice(0, 10);
 			
@@ -126,7 +129,7 @@ class SyntaxInfo extends Command {
 				msg.delete();
 				return sendEmbed(message, matchingSyntaxes[0]);
 			} else {
-				await msg.edit(`${matchingSyntaxes.length} élements trouvés pour la recherche \`${arg}\`. Quelle syntaxe vous interesse ?\n:warning: **Attendez que la réaction :x: soit posée avant de commencer.**`);
+				await msg.edit(`${results} élements trouvés pour la recherche \`${arg}\`. Quelle syntaxe vous interesse ?\n:warning: **Attendez que la réaction :x: soit posée avant de commencer.**`);
 				for (let i: number = 0; i < matchingSyntaxes.length; i++) {
 					msg = <Message> await msg.edit(`${msg.content}\n${reactionsNumbers[i]} \"${matchingSyntaxes[i].title}\" (${matchingSyntaxes[i].addon})`);
 					await msg.react(reactionsNumbers[i]);
@@ -156,7 +159,6 @@ class SyntaxInfo extends Command {
 						collectorStop.stop();
 					});
 			}
-			
 		}
 	}
 };

--- a/src/commands/tagRole.ts
+++ b/src/commands/tagRole.ts
@@ -1,0 +1,45 @@
+import { Message } from "discord.js";
+import Command from '../components/Command';
+import config from "../../config/config.json";
+import { discordError } from "../components/Messages";
+
+class TagRole extends Command {
+
+	name: string = 'Tag Role';
+	shortDescription: string = config.messages.commands.tagRole.shortDesc;
+	longDescription: string = config.messages.commands.tagRole.longDesc;
+	usage: string = `${config.bot.prefix}tag-role`;
+	examples: string[] = ['tagrole Notifications Évènements'];
+	regex: RegExp = /(?:tag|mention|notif)-?role/gmui;
+	permissions: string[] = ['Staff'];
+
+	execute = async (message: Message, args: string[]): Promise<void> => {
+		if (args.length === 0) {
+			return discordError(config.messages.commands.tagRole.invalidCmd, message);
+		} else {
+			message.delete();
+			let role = message.guild.roles.find(r => r.name.toUpperCase() === args.join(' ').toUpperCase());
+			if (role) {
+				if (!role.mentionable) {
+					try {
+						role.setMentionable(true);
+					} catch (err) {
+						console.error(`An error occured while attempting to set the mentionable state of role ${role} to true. Error : ${err}`);
+					}
+				}
+				await message.channel.send(`${role}`);
+				if (role.mentionable){
+					try {
+						role.setMentionable(false);
+					} catch (err) {
+						console.error(`An error occured while attempting to set the mentionable state of role ${role} to false. Error : ${err}`);
+					}
+				}
+			} else {
+				return discordError(config.messages.commands.tagRole.invalidRole.replace('%s', args.join(' ')), message);
+			}
+		}
+	}
+};
+
+export default TagRole;

--- a/src/components/Command.ts
+++ b/src/components/Command.ts
@@ -7,16 +7,21 @@ abstract class Command {
 	 * @property {string} name - Nom de la commande
 	 * @property {string} description - Description de la commande
 	 * @property {RegExp[]} regex - Patterns regex de la commande
+	 * @property {string} utilisation - Pattern de la commande (human-readable)
 	 * @property {string[]} examples - Exemples d'utilisation de la commande
+	 * NOT USABLE YET @property {boolean} hidden - La commande doit-elle être cachée dans la page d'aide. Oui = cachée.
 	 * @property {string[]} [permissions=config.bot.default_permissions] - Rôles requis par l'utilisateur pour
 	 * executer la commande
 	 * @property {string[]} [channels] - ID des channels dans lesquels la commande est utilisable
 	 */
 
 	public abstract name: string;
-	public abstract description: string;
+	public abstract shortDescription: string;
+	public abstract longDescription: string;
 	public abstract regex: RegExp;
+	public abstract usage: string;
 	public abstract examples: string[];
+	//public hidden: boolean = false;
 	public permissions: string[] = config.bot.default_permissions;
 	public channels: string[] = config.bot.default_channels;
 	public setup: Function = (): void => {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,19 +34,19 @@ client.then(client => {
 				const regex: RegExp = new RegExp(`^\\${config.bot.prefix}${command.regex.source}`, command.regex.flags);
 
 				if (message.content.match(regex)) {
-					if ((!command.channels) || (!command.channels.includes(message.channel.id)) && !command.channels.includes('*')) {
+					if (!command.channels || (!command.channels.includes(message.channel.id)) && !command.channels.includes('*'))
 						return;
-					}
-					if (command.permissions && command.permissions.length > 0) {
+					else if (config.bot.forbidden_channels.includes(message.channel.id))
+						return message.delete();
+					else if (command.permissions && command.permissions.length > 0) {
 						for (let permission of command.permissions) {
 							if (message.member.roles.find(role => role.name === permission)) {
 								command.execute(message, message.content.split(' ').splice(1, message.content.split(' ').length));
 								break;
 							}
 						}
-					} else {
+					} else
 						command.execute(message, message.content.split(' ').splice(1, message.content.split(' ').length));
-					}
 				}
 			}
 		});

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,7 +2,7 @@ import Discord, { Client } from 'discord.js';
 import { readdirSync } from 'fs';
 import config from '../config/config.json';
 import Command from './components/Command';
-import { error, info, success } from './components/Messages';
+import { error, success } from './components/Messages';
 import fetch from 'node-fetch';
 
 export async function loadSkriptHubAPI(): Promise<any[]> {


### PR DESCRIPTION
Nouveautés de ce que j'ai fais ajrd :

- Nouvelles commandes : 
    - 8ball : on pose une question au bot, il répond par oui ou non (mdr lol xptdr mdrrr)
    - auto : permet d'envoyer un message déjà définit. Pour le moment : .auto asktoask / .auto helptemplate / .auto internalerror / .auto deprecated
    - math : évalue une expression mathématique de Skript et donne le résultat

- Changements : 
    - ajouts de channels dans lesquels les commandes ne fonctionnent pas. Actuellement : #annonces (information), #règles, #annonces (événement), #calendrier #idées, #snippets, #lesperles
    - Suppression de la permission Staff qui était la perm par défaut pour toutes les commandes
    - modifications de mon pseudo et de celui de uiytt
    - addNotifRole renommé en toggleNotifRole
    - ajout de la liste des aidons dans .addon-info
    - la commande d'aide affiche maintenant X commandes par page (configurable) plutôt qu'une par page, et on peut faire .help <commande> pour avoir des infos précises sur une commande
    - ajout d'une description courte et d'une description longue
    - ajout d'une limite a la commande purge