### PR TITLE
Ajout d'un argument à la commande .code

### DIFF
--- a/src/commands/basic/code.js
+++ b/src/commands/basic/code.js
@@ -8,6 +8,7 @@ class Code extends Command {
     this.usage = 'code [-l [-s <entier>]] <votre code>';
     this.examples = ['code broadcast "Yeah!"', 'code -l on join: message "salut !"'];
   }
+
   async execute(_client, message, args) {
     const printLines = args[0] === '-l';
     let startAtLine = 0;
@@ -64,11 +65,12 @@ class Code extends Command {
         collector.stop();
       });
   }
+
   isNumeric(str) {
     // On vérifie que ce soit bien un string
     if (typeof str !== 'string') return false;
     // On vérifie qu'il ne soit pas null et que le parseInt non plus
-    return !isNaN(str) && !isNaN(parseInt(str), 10);
+    return !isNaN(str) && !isNaN(parseInt(str, 10));
   }
 }
 

--- a/src/commands/basic/code.js
+++ b/src/commands/basic/code.js
@@ -5,13 +5,33 @@ class Code extends Command {
   constructor() {
     super('Code');
     this.aliases = ['code', 'balise'];
-    this.usage = 'code [-l] <votre code>';
+    this.usage = 'code [-l [-s <entier>]] <votre code>';
     this.examples = ['code broadcast "Yeah!"', 'code -l on join: message "salut !"'];
   }
 
   async execute(_client, message, args) {
+    
     const printLines = args[0] === '-l';
-    if (printLines) args.shift();
+    let startAtLine = 0;
+    
+    if (printLines) {
+      args.shift();
+      if (args[0] === "-s") {
+        args.shift();
+        const value = args.shift();
+        if (this.isNumeric(value)) {
+          // On enlève 1 car il est rajouté plus tard
+          startAtLine = parseInt(value) - 1;
+          // Pour éviter des p'tits malins
+          if (startAtLine < 0) startAtLine = 0;
+        } else {
+          // Si c'est pas un nombre après l'argument s on le réinjecte
+          // dans le tableau d'argument, au début
+          args.reverse().push(value)
+          args.reverse();
+        }
+      }
+    }
 
     let code = args.join(' ');
     if (code.length === 0) return message.channel.send(this.config.noCode);
@@ -22,8 +42,8 @@ class Code extends Command {
       const lines = code.split('\n');
       code = '';
       for (const [i, line] of lines.entries()) {
-        const space = lines.length.toString().length - (i + 1).toString().length;
-        code += `\n${i + 1}${' '.repeat(space)} | ${line}`;
+        const space = (startAtLine + lines.length).toString().length - (startAtLine + i + 1).toString().length;
+        code += `\n${startAtLine + i + 1}${' '.repeat(space)} | ${line}`;
       }
     }
 
@@ -47,6 +67,14 @@ class Code extends Command {
         collector.stop();
       });
   }
+
+  isNumeric(str) {
+    // On vérifie que ce soit bien un string
+    if (typeof str != "string") return false;
+    // On vérifie qu'il ne soit pas null et que le parseInt non plus
+    return !isNaN(str) && !isNaN(parseInt(str))
+  }
+
 }
 
 export default Code;

--- a/src/commands/basic/code.js
+++ b/src/commands/basic/code.js
@@ -8,26 +8,23 @@ class Code extends Command {
     this.usage = 'code [-l [-s <entier>]] <votre code>';
     this.examples = ['code broadcast "Yeah!"', 'code -l on join: message "salut !"'];
   }
-
   async execute(_client, message, args) {
-    
     const printLines = args[0] === '-l';
     let startAtLine = 0;
-    
     if (printLines) {
       args.shift();
-      if (args[0] === "-s") {
+      if (args[0] === '-s') {
         args.shift();
         const value = args.shift();
         if (this.isNumeric(value)) {
           // On enlève 1 car il est rajouté plus tard
-          startAtLine = parseInt(value) - 1;
+          startAtLine = parseInt(value, 10) - 1;
           // Pour éviter des p'tits malins
           if (startAtLine < 0) startAtLine = 0;
         } else {
           // Si c'est pas un nombre après l'argument s on le réinjecte
           // dans le tableau d'argument, au début
-          args.reverse().push(value)
+          args.reverse().push(value);
           args.reverse();
         }
       }
@@ -67,14 +64,12 @@ class Code extends Command {
         collector.stop();
       });
   }
-
   isNumeric(str) {
     // On vérifie que ce soit bien un string
-    if (typeof str != "string") return false;
+    if (typeof str !== 'string') return false;
     // On vérifie qu'il ne soit pas null et que le parseInt non plus
-    return !isNaN(str) && !isNaN(parseInt(str))
+    return !isNaN(str) && !isNaN(parseInt(str), 10);
   }
-
 }
 
 export default Code;

--- a/src/commands/basic/code.js
+++ b/src/commands/basic/code.js
@@ -16,17 +16,16 @@ class Code extends Command {
       args.shift();
       if (args[0] === '-s') {
         args.shift();
-        const value = args.shift();
-        if (this.isNumeric(value)) {
+        const value = parseInt(args.shift(), 10);
+        if (!isNaN(value)) {
           // On enlève 1 car il est rajouté plus tard
-          startAtLine = parseInt(value, 10) - 1;
+          startAtLine = value - 1;
           // Pour éviter des p'tits malins
           if (startAtLine < 0) startAtLine = 0;
         } else {
           // Si c'est pas un nombre après l'argument s on le réinjecte
           // dans le tableau d'argument, au début
-          args.reverse().push(value);
-          args.reverse();
+          args.unshift(value);
         }
       }
     }
@@ -64,13 +63,6 @@ class Code extends Command {
         for (const block of codeBlocks) block.delete();
         collector.stop();
       });
-  }
-
-  isNumeric(str) {
-    // On vérifie que ce soit bien un string
-    if (typeof str !== 'string') return false;
-    // On vérifie qu'il ne soit pas null et que le parseInt non plus
-    return !isNaN(str) && !isNaN(parseInt(str, 10));
   }
 }
 


### PR DESCRIPTION
Bonjour, voici un petit ajout qui peut se révéler utile : un argument permettant de définir à partir de quelle ligne le code commence. En effet, on se retrouve souvent à partager son code mais les numéros de lignes peuvent souvent être décalés. C'est pourquoi je propose ce petit ajout afin de pouvoir régler ce décalage.
J'ai choisi "s" pour l'argument comme pour "startAt".

Exemple concret (il faut imaginer une possible trace venant de ce code) :
![image](https://user-images.githubusercontent.com/44125445/103785965-1ecddd80-503c-11eb-86cf-cf4432c0a039.png)
