### PR TITLE
✨ Add message logging

### DIFF
--- a/src/SwanClient.ts
+++ b/src/SwanClient.ts
@@ -271,7 +271,6 @@ class SwanClient extends AkairoClient {
       value: [],
     }).catch(nullop);
     this.cache.savedChannelsIds = configDocument?.value as string[];
-    console.log(this.cache.savedChannelsIds);
   }
 
   private async _loadSkriptToolsAddons(): Promise<void> {

--- a/src/SwanClient.ts
+++ b/src/SwanClient.ts
@@ -30,6 +30,7 @@ import type {
   SkriptToolsAddonListResponse,
   SwanModuleDocument,
 } from './types';
+import { SharedConfigName } from './types';
 import { nullop, uncapitalize } from './utils';
 
 class SwanClient extends AkairoClient {
@@ -264,12 +265,13 @@ class SwanClient extends AkairoClient {
   private async _loadSharedConfigs(): Promise<void> {
     // Load logged channels
     const configDocument: SharedConfigDocument = await sharedConfig.findOneOrCreate({
-      name: 'logged-channels',
+      name: SharedConfigName.LoggedChannels,
     }, {
-      name: 'logged-channels',
+      name: SharedConfigName.LoggedChannels,
       value: [],
     }).catch(nullop);
     this.cache.savedChannelsIds = configDocument?.value as string[];
+    console.log(this.cache.savedChannelsIds);
   }
 
   private async _loadSkriptToolsAddons(): Promise<void> {

--- a/src/SwanClient.ts
+++ b/src/SwanClient.ts
@@ -263,7 +263,12 @@ class SwanClient extends AkairoClient {
 
   private async _loadSharedConfigs(): Promise<void> {
     // Load logged channels
-    const configDocument: SharedConfigDocument = await sharedConfig.findOne({ name: 'logged-channels' }).catch(nullop);
+    const configDocument: SharedConfigDocument = await sharedConfig.findOneOrCreate({
+      name: 'logged-channels',
+    }, {
+      name: 'logged-channels',
+      value: [],
+    }).catch(nullop);
     this.cache.savedChannelsIds = configDocument?.value as string[];
   }
 

--- a/src/SwanClient.ts
+++ b/src/SwanClient.ts
@@ -11,6 +11,7 @@ import { Intents } from 'discord.js';
 import type { PermissionString } from 'discord.js';
 import mongoose from 'mongoose';
 import type { Query } from 'mongoose';
+import sharedConfig from '@/app/models/sharedConfig';
 import messages from '@/conf/messages';
 import settings from '@/conf/settings';
 import CommandStat from './models/commandStat';
@@ -22,6 +23,7 @@ import SwanCacheManager from './structures/SwanCacheManager';
 import TaskHandler from './structures/TaskHandler';
 import type {
   CommandStatDocument,
+  SharedConfigDocument,
   SkriptMcDocumentationFullAddonResponse,
   SkriptMcDocumentationSyntaxAndAddon,
   SkriptMcDocumentationSyntaxResponse,
@@ -158,6 +160,7 @@ class SwanClient extends AkairoClient {
     Logger.info('Loading & caching databases...');
     void this._loadPolls();
     void this._loadCommandStats();
+    void this._loadSharedConfigs();
 
     Logger.info('Loading addons from SkriptTools...');
     void this._loadSkriptToolsAddons();
@@ -256,6 +259,12 @@ class SwanClient extends AkairoClient {
       Logger.error('Could not load some documents:');
       Logger.error((unknownError as Error).stack);
     }
+  }
+
+  private async _loadSharedConfigs(): Promise<void> {
+    // Load logged channels
+    const configDocument: SharedConfigDocument = await sharedConfig.findOne({ name: 'logged-channels' }).catch(nullop);
+    this.cache.savedChannelsIds = configDocument?.value as string[];
   }
 
   private async _loadSkriptToolsAddons(): Promise<void> {

--- a/src/commands/admin/refresh.ts
+++ b/src/commands/admin/refresh.ts
@@ -3,6 +3,7 @@ import { Command } from 'discord-akairo';
 import sharedConfig from '@/app/models/sharedConfig';
 import SwanModule from '@/app/models/swanModule';
 import type { GuildMessage, SharedConfigDocument } from '@/app/types';
+import { SharedConfigName } from '@/app/types';
 import type { RefreshCommandArgument } from '@/app/types/CommandArguments';
 import { nullop } from '@/app/utils';
 import { refresh as config } from '@/conf/commands/admin';
@@ -38,7 +39,9 @@ class RefreshCommand extends Command {
     }
 
     // Refresh saved channels
-    const configDocument: SharedConfigDocument = await sharedConfig.findOne({ name: 'logged-channels' }).catch(nullop);
+    const configDocument: SharedConfigDocument = await sharedConfig.findOne({
+      name: SharedConfigName.LoggedChannels,
+    }).catch(nullop);
     this.client.cache.savedChannelsIds = configDocument?.value as string[];
 
     await message.channel.send(config.messages.success);

--- a/src/listeners/client/messageDelete.ts
+++ b/src/listeners/client/messageDelete.ts
@@ -2,6 +2,7 @@ import { Listener } from 'discord-akairo';
 import { DMChannel, User } from 'discord.js';
 import type { Message, MessageReaction } from 'discord.js';
 import pupa from 'pupa';
+import MessageLogManager from '@/app/structures/MessageLogManager';
 import type { GuildMessage } from '@/app/types';
 import { noop } from '@/app/utils';
 import messages from '@/conf/messages';
@@ -20,6 +21,7 @@ class MessageDeleteListener extends Listener {
       return;
 
     const message = globalMessage as GuildMessage;
+    await MessageLogManager.saveMessageDelete(this.client, message);
 
     if (message.author.bot
       || message.system

--- a/src/listeners/client/messageUpdate.ts
+++ b/src/listeners/client/messageUpdate.ts
@@ -2,6 +2,7 @@ import { Listener } from 'discord-akairo';
 import { User } from 'discord.js';
 import type { MessageReaction } from 'discord.js';
 import pupa from 'pupa';
+import MessageLogManager from '@/app/structures/MessageLogManager';
 import type { GuildMessage } from '@/app/types';
 import { noop, trimText } from '@/app/utils';
 import messages from '@/conf/messages';
@@ -16,6 +17,8 @@ class MessageUpdateListener extends Listener {
   }
 
   public async exec(oldMessage: GuildMessage, newMessage: GuildMessage): Promise<void> {
+    await MessageLogManager.saveMessageEdit(this.client, oldMessage, newMessage);
+
     // Prevent active members from posting another documentation than Skript-MC's.
     if (newMessage.member.roles.cache.has(settings.roles.activeMember)
       && (settings.miscellaneous.activeMemberBlacklistedLinks.some(link => newMessage.content.includes(link)))) {

--- a/src/models/discordUser.ts
+++ b/src/models/discordUser.ts
@@ -1,0 +1,29 @@
+import type { FilterQuery } from 'mongoose';
+import { model, Schema } from 'mongoose';
+import type { DiscordUserBase, DiscordUserDocument, DiscordUserModel } from '@/app/types';
+
+const DiscordUserSchema = new Schema<DiscordUserDocument, DiscordUserModel>({
+  userId: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  username: {
+    type: String,
+    required: true,
+  },
+  avatarUrl: {
+    type: String,
+  },
+});
+
+DiscordUserSchema.statics.findOneOrCreate = async function (
+  this: DiscordUserModel,
+  condition: FilterQuery<DiscordUserDocument>,
+  doc: DiscordUserBase,
+): Promise<DiscordUserDocument> {
+  const result = await this.findOne(condition);
+  return result || this.create(doc);
+};
+
+export default model<DiscordUserDocument, DiscordUserModel>('DiscordUser', DiscordUserSchema);

--- a/src/models/messageLog.ts
+++ b/src/models/messageLog.ts
@@ -1,0 +1,34 @@
+import { model, Schema } from 'mongoose';
+import type { MessageLogDocument, MessageLogModel } from '@/app/types';
+
+const MessageLogSchema = new Schema<MessageLogDocument, MessageLogModel>({
+  user: {
+    type: Schema.Types.ObjectId,
+    required: true,
+    ref: 'DiscordUser',
+    autopopulate: true,
+  },
+  messageId: {
+    type: String,
+    required: true,
+  },
+  channelId: {
+    type: String,
+    required: true,
+  },
+  oldContent: {
+    type: String,
+    required: true,
+  },
+  editions: {
+    type: [String],
+    required: true,
+    default: [],
+  },
+  newContent: {
+    type: String,
+    default: null,
+  },
+});
+
+export default model<MessageLogDocument, MessageLogModel>('MessageLog', MessageLogSchema);

--- a/src/models/sharedConfig.ts
+++ b/src/models/sharedConfig.ts
@@ -1,5 +1,6 @@
+import type { FilterQuery } from 'mongoose';
 import { model, Schema } from 'mongoose';
-import type { SharedConfigDocument, SharedConfigModel } from '@/app/types';
+import type { SharedConfigBase, SharedConfigDocument, SharedConfigModel } from '@/app/types';
 
 const SharedConfigSchema = new Schema<SharedConfigDocument, SharedConfigModel>({
   name: {
@@ -12,5 +13,14 @@ const SharedConfigSchema = new Schema<SharedConfigDocument, SharedConfigModel>({
     required: true,
   },
 });
+
+SharedConfigSchema.statics.findOneOrCreate = async function (
+  this: SharedConfigModel,
+  condition: FilterQuery<SharedConfigDocument>,
+  doc: SharedConfigBase,
+): Promise<SharedConfigDocument> {
+  const result = await this.findOne(condition);
+  return result || this.create(doc);
+};
 
 export default model<SharedConfigDocument, SharedConfigModel>('SharedConfig', SharedConfigSchema);

--- a/src/models/sharedConfig.ts
+++ b/src/models/sharedConfig.ts
@@ -1,11 +1,14 @@
 import type { FilterQuery } from 'mongoose';
 import { model, Schema } from 'mongoose';
 import type { SharedConfigBase, SharedConfigDocument, SharedConfigModel } from '@/app/types';
+import { SharedConfigName } from '@/app/types';
 
 const SharedConfigSchema = new Schema<SharedConfigDocument, SharedConfigModel>({
   name: {
     type: String,
     required: true,
+    enum: SharedConfigName,
+    default: SharedConfigName.LoggedChannels,
     unique: true,
   },
   value: {

--- a/src/models/sharedConfig.ts
+++ b/src/models/sharedConfig.ts
@@ -1,0 +1,16 @@
+import { model, Schema } from 'mongoose';
+import type { SharedConfigDocument, SharedConfigModel } from '@/app/types';
+
+const SharedConfigSchema = new Schema<SharedConfigDocument, SharedConfigModel>({
+  name: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  value: {
+    type: Schema.Types.Mixed,
+    required: true,
+  },
+});
+
+export default model<SharedConfigDocument, SharedConfigModel>('SharedConfig', SharedConfigSchema);

--- a/src/structures/MessageLogManager.ts
+++ b/src/structures/MessageLogManager.ts
@@ -1,0 +1,69 @@
+import type { AkairoClient } from 'discord-akairo';
+import type { Message, User } from 'discord.js';
+import discordUser from '@/app/models/discordUser';
+import messageHistory from '@/app/models/messageLog';
+import type { DiscordUserDocument, MessageLogDocument } from '@/app/types';
+
+export default {
+
+  shouldMessageBeSaved(client: AkairoClient, message: Message): boolean {
+    return client.cache.savedChannelsIds?.includes(message.channel.id) || false;
+  },
+
+  async getDiscordUser(client: AkairoClient, author: User): Promise<DiscordUserDocument | null> {
+    const cachedUser: DiscordUserDocument = client.cache.discordUsers.find(elt => elt.userId === author.id);
+    if (cachedUser)
+      return cachedUser;
+    const user: DiscordUserDocument = await discordUser.findOneOrCreate({
+      userId: author.id,
+    }, {
+      userId: author.id,
+      username: author.username,
+      avatarUrl: author.avatarURL(),
+    });
+    client.cache.discordUsers.push(user);
+    return user;
+  },
+
+  async saveMessageEdit(client: AkairoClient, oldMessage: Message, newMessage: Message): Promise<void> {
+    if (!this.shouldMessageBeSaved(client, oldMessage))
+      return;
+    const userDoc: DiscordUserDocument = await this.getDiscordUser(client, oldMessage.author);
+    const messageDoc: MessageLogDocument = await messageHistory.findOne({ messageId: oldMessage.id });
+    if (messageDoc) {
+      const oldNewContent = messageDoc.newContent;
+      if (oldNewContent)
+        messageDoc.editions.push(oldNewContent);
+      messageDoc.newContent = newMessage.content;
+      await messageDoc.save();
+    } else {
+      await messageHistory.create({
+        user: userDoc,
+        messageId: oldMessage.id,
+        channelId: oldMessage.channel.id,
+        oldContent: oldMessage.content,
+        newContent: newMessage.content,
+      });
+    }
+  },
+
+  async saveMessageDelete(client: AkairoClient, oldMessage: Message): Promise<void> {
+    if (!this.shouldMessageBeSaved(client, oldMessage))
+      return;
+    const userDoc: DiscordUserDocument = await this.getDiscordUser(client, oldMessage.author);
+    const messageDoc: MessageLogDocument = await messageHistory.findOne({ messageId: oldMessage.id });
+    if (messageDoc) {
+      messageDoc.editions.push(messageDoc.newContent);
+      messageDoc.newContent = null;
+      await messageDoc.save();
+    } else {
+      await messageHistory.create({
+        user: userDoc,
+        messageId: oldMessage.id,
+        channelId: oldMessage.channel.id,
+        oldContent: oldMessage.content,
+      });
+    }
+  },
+
+};

--- a/src/structures/MessageLogManager.ts
+++ b/src/structures/MessageLogManager.ts
@@ -5,7 +5,6 @@ import messageHistory from '@/app/models/messageLog';
 import type { DiscordUserDocument, MessageLogDocument } from '@/app/types';
 
 export default {
-
   shouldMessageBeSaved(client: AkairoClient, message: Message): boolean {
     return client.cache.savedChannelsIds?.includes(message.channel.id) || false;
   },

--- a/src/structures/MessageLogManager.ts
+++ b/src/structures/MessageLogManager.ts
@@ -64,5 +64,4 @@ export default {
       });
     }
   },
-
 };

--- a/src/structures/MessageLogManager.ts
+++ b/src/structures/MessageLogManager.ts
@@ -5,7 +5,7 @@ import messageHistory from '@/app/models/messageLog';
 import type { DiscordUserDocument, MessageLogDocument } from '@/app/types';
 
 export default {
-  shouldMessageBeSaved(client: AkairoClient, message: Message): boolean {
+  shouldSaveMessage(client: AkairoClient, message: Message): boolean {
     return client.cache.savedChannelsIds?.includes(message.channel.id) || false;
   },
 
@@ -25,7 +25,8 @@ export default {
   },
 
   async saveMessageEdit(client: AkairoClient, oldMessage: Message, newMessage: Message): Promise<void> {
-    if (!this.shouldMessageBeSaved(client, oldMessage))
+    // We check that the content of the message has changed, since it may not have changed
+    if (!this.shouldSaveMessage(client, oldMessage) || oldMessage.content === newMessage.content)
       return;
     const userDoc: DiscordUserDocument = await this.getDiscordUser(client, oldMessage.author);
     const messageDoc: MessageLogDocument = await messageHistory.findOne({ messageId: oldMessage.id });
@@ -47,7 +48,7 @@ export default {
   },
 
   async saveMessageDelete(client: AkairoClient, oldMessage: Message): Promise<void> {
-    if (!this.shouldMessageBeSaved(client, oldMessage))
+    if (!this.shouldSaveMessage(client, oldMessage))
       return;
     const userDoc: DiscordUserDocument = await this.getDiscordUser(client, oldMessage.author);
     const messageDoc: MessageLogDocument = await messageHistory.findOne({ messageId: oldMessage.id });

--- a/src/structures/MessageLogManager.ts
+++ b/src/structures/MessageLogManager.ts
@@ -1,7 +1,7 @@
 import type { AkairoClient } from 'discord-akairo';
 import type { Message, User } from 'discord.js';
-import discordUser from '@/app/models/discordUser';
-import messageHistory from '@/app/models/messageLog';
+import DiscordUser from '@/app/models/discordUser';
+import MessageLog from '@/app/models/messageLog';
 import type { DiscordUserDocument, MessageLogDocument } from '@/app/types';
 
 export default {
@@ -13,7 +13,7 @@ export default {
     const cachedUser: DiscordUserDocument = client.cache.discordUsers.find(elt => elt.userId === author.id);
     if (cachedUser)
       return cachedUser;
-    const user: DiscordUserDocument = await discordUser.findOneOrCreate({
+    const user: DiscordUserDocument = await DiscordUser.findOneOrCreate({
       userId: author.id,
     }, {
       userId: author.id,
@@ -29,7 +29,7 @@ export default {
     if (!this.shouldSaveMessage(client, oldMessage) || oldMessage.content === newMessage.content)
       return;
     const userDoc: DiscordUserDocument = await this.getDiscordUser(client, oldMessage.author);
-    const messageDoc: MessageLogDocument = await messageHistory.findOne({ messageId: oldMessage.id });
+    const messageDoc: MessageLogDocument = await MessageLog.findOne({ messageId: oldMessage.id });
     if (messageDoc) {
       const oldNewContent = messageDoc.newContent;
       if (oldNewContent)
@@ -37,7 +37,7 @@ export default {
       messageDoc.newContent = newMessage.content;
       await messageDoc.save();
     } else {
-      await messageHistory.create({
+      await MessageLog.create({
         user: userDoc,
         messageId: oldMessage.id,
         channelId: oldMessage.channel.id,
@@ -51,13 +51,13 @@ export default {
     if (!this.shouldSaveMessage(client, oldMessage))
       return;
     const userDoc: DiscordUserDocument = await this.getDiscordUser(client, oldMessage.author);
-    const messageDoc: MessageLogDocument = await messageHistory.findOne({ messageId: oldMessage.id });
+    const messageDoc: MessageLogDocument = await MessageLog.findOne({ messageId: oldMessage.id });
     if (messageDoc) {
       messageDoc.editions.push(messageDoc.newContent);
       messageDoc.newContent = null;
       await messageDoc.save();
     } else {
-      await messageHistory.create({
+      await MessageLog.create({
         user: userDoc,
         messageId: oldMessage.id,
         channelId: oldMessage.channel.id,

--- a/src/structures/SwanCacheManager.ts
+++ b/src/structures/SwanCacheManager.ts
@@ -1,6 +1,7 @@
 import type { AkairoModule } from 'discord-akairo';
 import type {
   CachedChannels,
+  DiscordUserDocument,
   GithubPrerelease,
   GithubStableRelease,
   Nullable,
@@ -20,6 +21,8 @@ class SwanCacheManager {
   modules: AkairoModule[];
   github: GithubCache;
   gitCommit: string;
+  discordUsers: DiscordUserDocument[];
+  savedChannelsIds: string[];
 
   constructor() {
     this.channels = {
@@ -43,6 +46,8 @@ class SwanCacheManager {
     this.pollMessagesIds = [];
     this.modules = [];
     this.gitCommit = '';
+    this.discordUsers = [];
+    this.savedChannelsIds = [];
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -657,3 +657,81 @@ export interface SanctionPopulatedDocument extends SanctionBaseDocument {
 export type SanctionModel = Model<SanctionDocument>;
 
 // #endregion
+
+/* ****************************** */
+/*   DiscordUser Database Types   */
+/* ****************************** */
+
+// #region DiscordUser Database Types (VS Code)
+// region DiscordUser Database Types (JetBrains)
+
+/** Interface for the "DiscordUser"'s mongoose schema */
+export interface DiscordUserBase {
+  userId: string;
+  username: string;
+  avatarUrl?: string;
+}
+
+/** Interface for the "DiscordUser"'s mongoose document */
+export interface DiscordUserDocument extends DiscordUserBase, Document {}
+
+/** Interface for the "DiscordUser"'s mongoose model */
+export interface DiscordUserModel extends Model<DiscordUserDocument> {
+  findOneOrCreate(
+    condition: FilterQuery<DiscordUserDocument>,
+    doc: DiscordUserBase,
+  ): Promise<DiscordUserDocument>;
+}
+
+// #endregion
+
+/* ****************************** */
+/*   SharedConfig Database Types   */
+/* ****************************** */
+
+// #region SharedConfig Database Types (VS Code)
+// region SharedConfig Database Types (JetBrains)
+
+/** Interface for the "SharedConfig"'s mongoose schema */
+export interface SharedConfigBase {
+  name: string;
+  value: unknown;
+}
+
+/** Interface for the "SharedConfig"'s mongoose document */
+export interface SharedConfigDocument extends SharedConfigBase, Document {}
+
+/** Interface for the "SharedConfig"'s mongoose model */
+export interface SharedConfigModel extends Model<SharedConfigDocument> {
+  findOneOrCreate(
+    condition: FilterQuery<SharedConfigDocument>,
+    doc: SharedConfigBase,
+  ): Promise<SharedConfigDocument>;
+}
+
+// #endregion
+
+/* ****************************** */
+/*   MessageLog Database Types   */
+/* ****************************** */
+
+// #region MessageLog Database Types (VS Code)
+// region MessageLog Database Types (JetBrains)
+
+/** Interface for the "MessageLog"'s mongoose schema */
+export interface MessageLogBase {
+  user: DiscordUserDocument;
+  messageId: string;
+  channelId: string;
+  oldContent: string;
+  editions: string[];
+  newContent?: string;
+}
+
+/** Interface for the "MessageLog"'s mongoose document */
+export interface MessageLogDocument extends MessageLogBase, Document {}
+
+/** Interface for the "MessageLog"'s mongoose model */
+export type MessageLogModel = Model<MessageLogDocument>;
+
+// #endregion

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -692,9 +692,14 @@ export interface DiscordUserModel extends Model<DiscordUserDocument> {
 // #region SharedConfig Database Types (VS Code)
 // region SharedConfig Database Types (JetBrains)
 
+/** Enum for the "SharedConfig"'s mongoose schema */
+export enum SharedConfigName {
+  LoggedChannels = 'logged-channels',
+}
+
 /** Interface for the "SharedConfig"'s mongoose schema */
 export interface SharedConfigBase {
-  name: string;
+  name: SharedConfigName;
   value: unknown;
 }
 


### PR DESCRIPTION
Cette Pull Request apporte l'ajout d'un système pour enregistrer les messages édités et supprimés pour faciliter la modération du serveur. Les messages pourront être par la suite consultés sur le panel, où l'on peut aussi choisir les salons à sauvegarder et ceux qui ne le seront pas. Les IDs des salons où les messages doivent être enregistrés sont chargés au lancement de Swan, et de la même manière que les modules, peuvent être rafraîchis avec la commande `.refresh` si l'on vient à les modifier sur le panel. Pour l'enregistrement des messages, j'ai mis en place un cache des utilisateurs Discord, afin de ne pas appeler à chaque édition ou suppression la base de donnée. Je fais cette PR surtout pour avoir vos avis sur la façon dont j'ai procédé, donc n'hésitez pas s'il y a des choses à modifier !