### PR TITLE
:fire: Remove blacklisting of documentations links

### DIFF
--- a/config/settings.ts
+++ b/config/settings.ts
@@ -26,10 +26,6 @@ export default {
     permanentKeywords: ['def', 'déf', 'definitif', 'définitif', 'perm', 'perma', 'permanent'],
     hastebinExtensions: ['.sk', '.yml', '.yaml', '.txt', '.json', '.js', '.ts', '.md', '.java'],
     connectionCheckDuration: 15_000, // 15 seconds in milliseconds
-    activeMemberBlacklistedLinks: [
-      'skripthub.net/docs',
-      'docs.skunity.com',
-    ],
     booleanTruths: ['oui', 'o', 'yes', 'y', 'vrai', 'v', 'true', 't', 'on'],
     booleanFalses: ['non', 'no', 'n', 'faux', 'f', 'false', 'off'],
   },

--- a/src/listeners/client/messageUpdate.ts
+++ b/src/listeners/client/messageUpdate.ts
@@ -1,11 +1,10 @@
-import { MessageLimits } from '@sapphire/discord-utilities';
 import { Listener } from '@sapphire/framework';
 import type { MessageReaction } from 'discord.js';
 import { User } from 'discord.js';
 import pupa from 'pupa';
 import MessageLogManager from '@/app/structures/MessageLogManager';
 import type { GuildMessage } from '@/app/types';
-import { noop, trimText } from '@/app/utils';
+import { noop } from '@/app/utils';
 import messages from '@/conf/messages';
 import settings from '@/conf/settings';
 

--- a/src/listeners/client/messageUpdate.ts
+++ b/src/listeners/client/messageUpdate.ts
@@ -19,19 +19,6 @@ export default class MessageUpdateListener extends Listener {
       || newMessage.member.roles.highest.position >= newMessage.guild.roles.cache.get(settings.roles.staff)!.position)
       return;
 
-    // Prevent active members from posting another documentation than Skript-MC's.
-    if (newMessage.member.roles.cache.has(settings.roles.activeMember)
-      && (settings.miscellaneous.activeMemberBlacklistedLinks.some(link => newMessage.content.includes(link)))) {
-      await newMessage.delete();
-      const finalLength = (oldMessage.content.length + messages.miscellaneous.noDocLink.length);
-      const content = finalLength >= MessageLimits.MaximumLength
-        ? trimText(oldMessage.content, MessageLimits.MaximumLength - messages.miscellaneous.noDocLink.length - 3)
-        : oldMessage.content;
-      await newMessage.author.send(pupa(messages.miscellaneous.noDocLink, { content }));
-
-      return;
-    }
-
     // Check for ghostpings.
     // List of all users that were mentionned in the old message.
     const oldUserMentions = [...oldMessage.mentions.users.values()]


### PR DESCRIPTION
Cette PR retire le système qui empêche les membres ayant le rôle Membre Notable (anciennement Membre actif) de poster des liens de documentations en anglais (skripthub et skunity).