### PR TITLE
Last minute fixes

### DIFF
--- a/config/commands/info.ts
+++ b/config/commands/info.ts
@@ -17,6 +17,7 @@ export const addonInfo = {
     embed: {
       title: 'Informations sur {addon.plugin}',
       noDescription: 'Aucune description disponible.',
+      description: "{description}\n\n:warning: *Il se peut que ces informations ne soit à jour. Veuillez vérifier par vous-même sur la page officielle de l'addon afin de rester à jour.*",
       author: ':bust_in_silhouette: Auteur(s)',
       version: ':gear: Dernière version',
       download: ':inbox_tray: Lien de téléchargement',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swan",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swan",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@octokit/rest": "^19.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swan",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Bot discord de Skript-MC.",
   "main": "./build/src/main.js",
   "scripts": {

--- a/src/commands/info/addonInfo.ts
+++ b/src/commands/info/addonInfo.ts
@@ -74,7 +74,14 @@ export default class AddonInfoCommand extends SwanCommand {
       .setColor(settings.colors.default)
       .setAuthor({ name: pupa(embedMessages.title, { addon }) })
       .setTimestamp()
-      .setDescription(trimText(addon.description || embedMessages.noDescription, EmbedLimits.MaximumDescriptionLength))
+      .setDescription(
+        pupa(embedMessages.description, {
+          description: trimText(
+            addon.description || embedMessages.noDescription,
+            EmbedLimits.MaximumDescriptionLength - embedMessages.description.length,
+          ),
+        }),
+      )
       .setFooter({ text: pupa(embedMessages.footer, { member: interaction.member }) });
 
     if (addon.unmaintained)


### PR DESCRIPTION
- Fix du README
- Ajout d'un avertissement sur la commande `/addon-info` comme quoi les informations peuvent ne pas être à jour