### PR TITLE
📝 Replace old Weesky's Discord ID and tag

### DIFF
--- a/config/commands/basic.ts
+++ b/config/commands/basic.ts
@@ -199,7 +199,7 @@ export const statistics = {
       thanksContent: stripIndent`
         <@218505052015296512> : ancien développeur
         <@187971875845046272> : contributions
-        <@173542833364533249> : contributions
+        <@286246590585503745> : contributions
         <@435756597168308225> : contributions
         <@294134773901688833> : contributions
       `,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "contributors": [
     "Olyno (Olyno#1234)",
-    "WeeskyBDW (WeeskyBDW#6172)",
+    "WeeskyBDW (WeeskyBDW#9233)",
     "Aless (Aless#6161)",
     "Skylyxx (Skylyxx#8816)",
     "iTrooz_ (iTrooz_#2050)"


### PR DESCRIPTION
Suite à la perte de mon ancien compte discord, je change l'id et le tag par celui de mon nouveau compte